### PR TITLE
(0.27) Ignore unreachable paths in TR::GlobalValuePropagation::mergeDefinedO…

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4579,6 +4579,10 @@ TR_BitVector *TR::GlobalValuePropagation::mergeDefinedOnAllPaths(TR_StructureSub
    bool first = true;
    for (auto itr = node->getPredecessors().begin(), end = node->getPredecessors().end(); itr != end; ++itr)
       {
+      EdgeConstraints  *constraints = getEdgeConstraints(*itr);
+      if (isUnreachablePath(constraints))
+         continue;
+      
       TR_BitVector *predDefinedOnAllPaths = (*_definedOnAllPaths)[*itr];
       if (trace())
          {


### PR DESCRIPTION
Ignore unreachable paths when merging defined on all paths in GlobalVP.

When we are merging "defined on all" paths information from block
predecessors, we need to ignore the ones that have been proven
unreachable and therefore don't have that information calculated.
Since it's an intersection of the info from all predecessors,
resulting info becomes too conservative and does not allow propagation
that could've happened otherwise.

Port of https://github.com/eclipse/omr/pull/6048 for the 0.27 release.