### PR TITLE
(0.28.0) Avoid symbol reference sharing for dummy resolved methods

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1450,7 +1450,7 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
               && owningMethodIndex == symRef->getOwningMethodIndex()
               && cpIndex != -1
               && symRef->getSymbol()->getMethodSymbol()->getMethodKind() == callKind
-              && !(resolvedMethod && symRef->isUnresolved())
+              && !(resolvedMethod && (symRef->isUnresolved() || symRef->getSymbol()->isDummyResolvedMethod()))
             )
           return symRef;
         }


### PR DESCRIPTION
This is a fix for eclipse-openj9/openj9#13126. The same commit has been merged into OMR master in eclipse/omr#6169