### PR TITLE
(0.29.0) Consider guards in field privatizer

### DIFF
--- a/compiler/il/OMROpcodes.enum
+++ b/compiler/il/OMROpcodes.enum
@@ -7415,7 +7415,7 @@ OPCODE_MACRO(\
    /* .opcode               = */ instanceof, \
    /* .name                 = */ "instanceof", \
    /* .properties1          = */ ILProp1::HasSymbolRef, \
-   /* .properties2          = */ ILProp2::SupportedForPRE| ILProp2::MayUseSystemStack, \
+   /* .properties2          = */ ILProp2::MayUseSystemStack, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
    /* .dataType             = */ TR::Int32, \

--- a/compiler/optimizer/FieldPrivatizer.hpp
+++ b/compiler/optimizer/FieldPrivatizer.hpp
@@ -140,6 +140,16 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
    void detectFieldsThatCannotBePrivatized(TR::Node *, vcount_t);
    void detectFieldsThatCannotBePrivatized(TR_Structure *, vcount_t);
    bool canPrivatizeFieldSymRef(TR::Node *);
+
+   /**
+    * Checks whether \c currentNode represents a \ref TR::instanceof
+    * operation or whether any of its subtrees do.
+    *
+    * @param currentNode the node to check
+    * @return \c true if the subtree contains a \c TR::instanceof
+    * operation; \c false, otherwise.
+    */
+   bool subtreeHasInstanceOf(TR::Node *currentNode);
    bool containsEscapePoints(TR_Structure *, bool &);
    void addPrivatizedRegisterCandidates(TR_Structure *);
    bool isStringPeephole(TR::Node *, TR::TreeTop *);
@@ -163,6 +173,20 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
    List<TR::TreeTop> _appendCalls;
 
    TR_PostDominators *_postDominators;
+
+   /**
+    * Tracks whether a node and its subtrees have been checked to
+    * see whether they contain a \ref TR::instanceof operation.
+    * If so, \ref _subtreeHasInstanceOf can be checked for the
+    * presence of an \c TR::instanceof in the subtree.
+    */
+   TR::NodeChecklist _subtreeCheckedForInstanceOf;
+
+   /**
+    * Tracks whether a node or one or its subtrees performs a
+    * \ref TR::instanceof operation.
+    */
+   TR::NodeChecklist _subtreeHasInstanceOf;
    };
 
 

--- a/compiler/optimizer/FieldPrivatizer.hpp
+++ b/compiler/optimizer/FieldPrivatizer.hpp
@@ -149,7 +149,7 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
     * @return \c true if the subtree contains a \c TR::instanceof
     * operation; \c false, otherwise.
     */
-   bool subtreeHasInstanceOf(TR::Node *currentNode);
+   bool subtreeHasSpecialCondition(TR::Node *currentNode);
    bool containsEscapePoints(TR_Structure *, bool &);
    void addPrivatizedRegisterCandidates(TR_Structure *);
    bool isStringPeephole(TR::Node *, TR::TreeTop *);
@@ -175,18 +175,24 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
    TR_PostDominators *_postDominators;
 
    /**
-    * Tracks whether a node and its subtrees have been checked to
-    * see whether they contain a \ref TR::instanceof operation.
-    * If so, \ref _subtreeHasInstanceOf can be checked for the
-    * presence of an \c TR::instanceof in the subtree.
+    * Tracks whether the subtree rooted at a node has been
+    * checked via a call to \ref subtreeHasSpecialCondition(TR::Node*)
+    * to see whether it contains any "special conditions".
+    *
+    * If this checklist does not contain the node, that
+    * method must be called to perform the checking;
+    * if it does contain the node, the node is present in
+    * \ref _subtreeHasSpecialCondition if and only if the
+    * subtree rooted at the node contains any of those special
+    * conditions.
     */
-   TR::NodeChecklist _subtreeCheckedForInstanceOf;
+   TR::NodeChecklist _subtreeCheckedForSpecialConditions;
 
    /**
     * Tracks whether a node or one or its subtrees performs a
-    * \ref TR::instanceof operation.
+    * \ref TR::instanceof operation or a comparison to \c null.
     */
-   TR::NodeChecklist _subtreeHasInstanceOf;
+   TR::NodeChecklist _subtreeHasSpecialCondition;
    };
 
 


### PR DESCRIPTION
A reference or store to a field that came from an inlined method might be guarded by a virtual guard.  In any particular execution of the loop, such a field might not actually exist in the object that's being referenced.  To avoid that situation, this change adds a simple check for the existence of a virtual guard within the loop and considers it to be an escape point in the `containsEscapePoints` method.

Similarly, `instanceof` or null tests might guard accesses to fields that wouldn't necessarily exist every time a loop is executed, so they are considered escape points as well.

This pull request fixes [OpenJ9 issue #13524](https://github.com/eclipse-openj9/openj9/issues/13524)
It merges [OMR pull request #6187](https://github.com/eclipse/omr/pull/6187) to the v0.29.0-release branch.