### PR TITLE
(0.29.1) Prevent OSR transitions from failed guards

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1871,6 +1871,13 @@ TR_InlinerBase::addGuardForVirtual(
    else if (!disableHCRGuards && comp()->getHCRMode() != TR::none)
       createdHCRGuard = true;
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+// for inlined callee methods that do not have HCR guards, setting createdHCRGuard to false
+// prevents creating an OSR transition point to be taken in cases such as a failed TR_ProfiledGuard
+   if (skipHCRGuardForCallee)
+      createdHCRGuard = false;
+#endif
+
    static const char *disableFSDGuard = feGetEnv("TR_DisableFSDGuard");
    if ( !disableFSDGuard && comp()->getOption(TR_FullSpeedDebug) && guard->_kind != TR_BreakpointGuard)
       {


### PR DESCRIPTION
For inlined callee methods that we skip creating HCR guards for,
setting createdHCRGuard to false prevents creating an OSR
transition point to be taken in cases such as a failed
TR_ProfiledGuard.

Port of https://github.com/eclipse/omr/pull/6255 for the 0.29.1 release. 
Issue https://github.com/eclipse-openj9/openj9/issues/13162

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>