### PR TITLE
(0.33) Fix static init of vector types

### DIFF
--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -334,11 +334,3 @@ namespace TR{
    double getMaxDouble() { return fpLimits.getMaxDouble(); }
    double getMinDouble() { return fpLimits.getMinDouble(); }
 }
-
-
-const TR::DataTypes OMR::DataType::Vector128Int8   = OMR::DataType::createVectorType(TR::Int8, TR::VectorLength128);
-const TR::DataTypes OMR::DataType::Vector128Int16  = OMR::DataType::createVectorType(TR::Int16, TR::VectorLength128);
-const TR::DataTypes OMR::DataType::Vector128Int32  = OMR::DataType::createVectorType(TR::Int32, TR::VectorLength128);
-const TR::DataTypes OMR::DataType::Vector128Int64  = OMR::DataType::createVectorType(TR::Int64, TR::VectorLength128);
-const TR::DataTypes OMR::DataType::Vector128Float  = OMR::DataType::createVectorType(TR::Float, TR::VectorLength128);
-const TR::DataTypes OMR::DataType::Vector128Double = OMR::DataType::createVectorType(TR::Double, TR::VectorLength128);

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -349,18 +349,22 @@ namespace TR
 namespace OMR
 {
 
+// temporary macro to be used only by this class
+#define OMR_TEMPORARY_CREATE_VECTOR_TYPE(elementType, length) (static_cast<TR::DataTypes>(TR::NumScalarTypes + (length - 1) * TR::NumVectorElementTypes + elementType - 1))
+
 class OMR_EXTENSIBLE DataType
    {
 public:
 
+   // Needed to initialize static opcode properties table,
    // will be removed when all vector opcodes are switched to new ones
    // as well as TRIL and JitBuilder
-   static const TR::DataTypes Vector128Int8;
-   static const TR::DataTypes Vector128Int16;
-   static const TR::DataTypes Vector128Int32;
-   static const TR::DataTypes Vector128Int64;
-   static const TR::DataTypes Vector128Float;
-   static const TR::DataTypes Vector128Double;
+   static const TR::DataTypes Vector128Int8   = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Int8,   TR::VectorLength128);
+   static const TR::DataTypes Vector128Int16  = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Int16,  TR::VectorLength128);
+   static const TR::DataTypes Vector128Int32  = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Int32,  TR::VectorLength128);
+   static const TR::DataTypes Vector128Int64  = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Int64,  TR::VectorLength128);
+   static const TR::DataTypes Vector128Float  = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Float,  TR::VectorLength128);
+   static const TR::DataTypes Vector128Double = OMR_TEMPORARY_CREATE_VECTOR_TYPE(TR::Double, TR::VectorLength128);
 
    DataType() : _type(TR::NoType) { }
    DataType(TR::DataTypes t) : _type(t) { }

--- a/compiler/il/OMRDataTypes_inlines.hpp
+++ b/compiler/il/OMRDataTypes_inlines.hpp
@@ -214,7 +214,7 @@ OMR::DataType::createVectorType(TR::DataTypes elementType, TR::VectorLength leng
    TR_ASSERT_FATAL(length > TR::NoVectorLength && length <= TR::NumVectorLengths,
                    "Invalid vector length %d\n", length);
 
-   TR::DataTypes type = static_cast<TR::DataTypes>(TR::NumScalarTypes + (length-1) * TR::NumVectorElementTypes + elementType - 1);
+   TR::DataTypes type = OMR_TEMPORARY_CREATE_VECTOR_TYPE(elementType, length);
 
    return type;
    }

--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -58,6 +58,8 @@ OMR::ILOpCode::checkILOpArrayLengths()
 
       TR_ASSERT(props.opcode == opCode, "_opCodeProperties table out of sync at index %d, has %s\n", i, op.getName());
       }
+
+   TR_ASSERT_FATAL(_opCodeProperties[TR::viRegLoad].dataType == TR::DataType::createVectorType(TR::Int32, TR::VectorLength128), "Vector type was not initialized correctly\n");
    }
 
 // FIXME: We should put the smarts in the getSize() routine in TR::DataType


### PR DESCRIPTION
- C++ does not guarantee any order of static initialization of variables
defined in different compilation units
- Make OMR::DataType::Vector128Int32 and similar variables compile time constants

Port of https://github.com/eclipse/omr/pull/6534 for the 0.33 release.