### PR TITLE
[0.36.0] Check for right-hand operand of zero in lrem and irem

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6678,18 +6678,23 @@ TR::Node *constrainIrem(OMR::ValuePropagation *vp, TR::Node *node)
       int32_t rhsConst = rhs->asIntConst()->getInt();
       if (!isUnsigned && rhsConst < 0)
          rhsConst *= -1;
-      rhsConst--; // If the original const was 10, the range is from 0 to 9
 
-      if (lhsLow > 0)
-         constraint = TR::VPIntRange::create(vp, 0, rhsConst);
-      else if (!isUnsigned && lhsHigh < 0)
-         constraint = TR::VPIntRange::create(vp, -rhsConst, 0);
-      else if (!isUnsigned)
-         constraint = TR::VPIntRange::create(vp, -rhsConst, rhsConst);
-
-      if (constraint)
+      // Guard against division by zero
+      if (rhsConst != 0)
          {
-         vp->addBlockOrGlobalConstraint(node, constraint ,lhsGlobal);
+         rhsConst--; // If the original const was 10, the range is from 0 to 9
+
+         if (lhsLow > 0)
+            constraint = TR::VPIntRange::create(vp, 0, rhsConst);
+         else if (!isUnsigned && lhsHigh < 0)
+            constraint = TR::VPIntRange::create(vp, -rhsConst, 0);
+         else if (!isUnsigned)
+            constraint = TR::VPIntRange::create(vp, -rhsConst, rhsConst);
+
+         if (constraint)
+            {
+            vp->addBlockOrGlobalConstraint(node, constraint ,lhsGlobal);
+            }
          }
       }
 
@@ -6736,22 +6741,27 @@ TR::Node *constrainLrem(OMR::ValuePropagation *vp, TR::Node *node)
       int64_t rhsConst = rhs->asLongConst()->getLong();
       if (rhsConst < 0)
          rhsConst *= -1;
-      rhsConst--; // If the original const was 10, the range is from 0 to 9
 
-      if (lhsLow > 0)
-         constraint = TR::VPLongRange::create(vp, 0, rhsConst);
-      else if (lhsHigh < 0)
-         constraint = TR::VPLongRange::create(vp, -rhsConst, 0);
-      else
-         constraint = TR::VPLongRange::create(vp, -rhsConst, rhsConst);
-
-      if (constraint)
+      // Guard against division by zero
+      if (rhsConst != 0)
          {
-         bool didReduction = reduceLongOpToIntegerOp(vp, node, constraint);
-         vp->addBlockOrGlobalConstraint(node, constraint ,lhsGlobal);
+         rhsConst--; // If the original const was 10, the range is from 0 to 9
 
-         if (didReduction)
-            return node;
+         if (lhsLow > 0)
+            constraint = TR::VPLongRange::create(vp, 0, rhsConst);
+         else if (lhsHigh < 0)
+            constraint = TR::VPLongRange::create(vp, -rhsConst, 0);
+         else
+            constraint = TR::VPLongRange::create(vp, -rhsConst, rhsConst);
+
+         if (constraint)
+            {
+            bool didReduction = reduceLongOpToIntegerOp(vp, node, constraint);
+            vp->addBlockOrGlobalConstraint(node, constraint ,lhsGlobal);
+
+            if (didReduction)
+               return node;
+            }
          }
       }
 


### PR DESCRIPTION
 If the following program
 
```
public class Bug {
    public static final int sub(int i) {
        int[] arr = {1,2,3,4,5,6,7,8};
        long l = 0;
        return arr[-((int) (i % l))];
    }

    public static final void main(String[] args) {
        sub(1);
    }
}
```

is run with `java -Xjit:count=0 Bug`, the following assertion failure results:

```
Assertion failed at /root/hostdir/defects/issue15730/openj9-openjdk-jdk17/omr/compiler/optimizer/VPHandlers.cpp:8171: low <= high
VMState: 0x000514ff
        Node 0x7f87257752c0 [l2i]: reversed child constraint bounds
```

The problem is that the `constrainIrem` and `constrainLrem` Value Propagation handlers guard against a right-hand operand of zero if the left-hand operand is a constant, but not if the left-hand operand is a non-constant.  In the latter case, a constraint in the range [1,-1] results.  Notice that the upper bound of the range is less than the lower bound.

This change adds an additional check for a right-hand operand equal to zero if the left-hand operand is non-constant, avoiding creating an erroneous constraint for the result.

This pull request delivers the change from OMR pull request eclipse/omr#6864 to the openj9-omr v0.36.0-release branch.