### PR TITLE
(0.38.0) AArch64: Implement b2sEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -512,7 +512,7 @@ OMR::ARM64::TreeEvaluator::b2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 OMR::ARM64::TreeEvaluator::b2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::b2iEvaluator(node, cg);
    }
 
 TR::Register*


### PR DESCRIPTION
Add b2sEvaluator which just calls b2iEvaluator.

Master PR: https://github.com/eclipse/omr/pull/6928