### PR TITLE
WIP:Handle code cache allocation for low physical memory.

### DIFF
--- a/compiler/control/CompilationController.hpp
+++ b/compiler/control/CompilationController.hpp
@@ -27,6 +27,10 @@
 namespace TR { class CompilationStrategy; }
 namespace TR { class CompilationInfo; }
 
+//#include "control/CompilationRuntime.hpp"
+namespace OMR { class CompilationInfo;}
+namespace OMR { typedef CompilationInfo CompilationInfoConnector; }
+
 //------------------------------- TR::CompilationController ------------------------
 // All methods and fields are static. The most important field is _compilationStrategy
 // that store the compilation strategy in use.
@@ -54,4 +58,23 @@ class CompilationController
 
 } // namespace TR
 
+namespace OMR
+{
+class CompilationInfo
+   {
+   private:
+   bool _cgroupMemorySubsystemEnabled;
+   public:
+   CompilationInfo ();
+
+   /**
+   * @brief Compute free physical memory taking into account container limits
+   *
+   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered memory couldn't be read
+   * @return                 A value representing the free physicalMemory
+                             or OMRPORT_MEMINFO_NOT_AVAILABLE in case of error
+   */
+   uint64_t computeFreePhysicalMemory(bool &incompleteInfo);
+   };
+}
 #endif

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -29,6 +29,8 @@
 #include "env/FrontEnd.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
+#include "control/CompilationController.hpp"
+#include "control/CompilationRuntime.hpp"
 #include "env/IO.hpp"
 #include "env/defines.h"
 #include "env/CompilerEnv.hpp"
@@ -1041,6 +1043,9 @@ OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize,
    uint8_t* start = NULL;
    uint8_t* end = NULL;
    size_t freeSpace = 0;
+   bool incomplete;
+   TR::CompilationInfo *compInfo = TR::CompilationController::getCompilationInfo();
+   uint64_t freeMem = compInfo->computeFreePhysicalMemory(incomplete);
 
    TR::CodeCacheMemorySegment *repositorySegment = _codeCacheRepositorySegment;
 


### PR DESCRIPTION
In `OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize` calculate available physical memory and perform new code cache allocation if we have the safe amount returned for the memory.

Closes: #17011