### PR TITLE
(0.40.0) AArch64: Fix loadAddressConstantInSnippet()

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -4952,7 +4952,7 @@ TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *n
 
    if (isClassUnloadingConst)
       {
-      if (node->isMethodPointerConstant())
+      if (node->chkMethodPointerConstant())
          {
          cg->getMethodSnippetsToBePatchedOnClassUnload()->push_front(snippet);
          }


### PR DESCRIPTION
This commit replaces the call to isMethodPointerConstant() in loadAddressConstantInSnippet() by chkMethodPointerConstant(). The assertion in isMethodPointerConstant() could fail.

Original PR in master: https://github.com/eclipse/omr/pull/7033