### PR TITLE
Replace omrtime_current_time_millis() with omrtime_hires_clock() call in gc

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3288,7 +3288,7 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 	if (NULL == cache) {
 		env->_scavengerStats._scanCacheOverflow = 1;
 		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-		uint64_t duration = omrtime_current_time_millis();
+		uint64_t duration = omrtime_hires_clock();
 
 		bool resizePerformed = false;
 		omrthread_monitor_enter(_freeCacheMonitor);
@@ -3305,7 +3305,7 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 			/* Still need a new cache and nothing left reserved - create it in Heap */
 			cache = createCacheInHeap(env);
 		}
-		duration = omrtime_current_time_millis() - duration;
+		duration = omrtime_hires_clock() - duration;
 		env->_scavengerStats._scanCacheAllocationDurationDuringSavenger += duration;
 
 	}

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -291,7 +291,7 @@ MM_VerboseHandlerOutput::outputInitializedStanza(MM_EnvironmentBase *env, MM_Ver
 
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	Assert_MM_true(_manager->getInitializedTime() != 0);
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_hires_clock());
 
 	buffer->formatAndOutput(env, 0, "<initialized %s>", tagTemplate);
 	buffer->formatAndOutput(env, 1, "<attribute name=\"gcPolicy\" value=\"%s\" />", _extensions->gcModeString);
@@ -476,7 +476,7 @@ MM_VerboseHandlerOutput::handleCycleStart(J9HookInterface** hook, uintptr_t even
 	char tagTemplate[200];
 	uintptr_t id = _manager->getIdAndIncrement();
 	env->_cycleState->_verboseContextID = id;
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), id, cycleType, 0 /* Needs context id */, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), id, cycleType, 0 /* Needs context id */, omrtime_hires_clock());
 
 	enterAtomicReportingBlock();
 	if (!deltaTimeSuccess) {
@@ -504,7 +504,7 @@ MM_VerboseHandlerOutput::handleCycleContinue(J9HookInterface** hook, uintptr_t e
 	const char* newCycleType = getCurrentCycleType(env);
 	const char* oldCycleType = getCycleType(event->oldCycleType);
 	char tagTemplate[200];
-	getTagTemplateWithOldType(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), oldCycleType, newCycleType, env->_cycleState->_verboseContextID, omrtime_current_time_millis());
+	getTagTemplateWithOldType(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), oldCycleType, newCycleType, env->_cycleState->_verboseContextID, omrtime_hires_clock());
 
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<cycle-continue %s />", tagTemplate);
@@ -523,7 +523,7 @@ MM_VerboseHandlerOutput::handleCycleEnd(J9HookInterface** hook, uintptr_t eventN
 	const char* cycleType = getCurrentCycleType(env);
 	char tagTemplate[200];
 	char fixupTagTemplate[100];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), cycleType, env->_cycleState->_verboseContextID, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), cycleType, env->_cycleState->_verboseContextID, omrtime_hires_clock());
 
 	enterAtomicReportingBlock();
 	if(hasCycleEndInnerStanzas()) {
@@ -536,7 +536,7 @@ MM_VerboseHandlerOutput::handleCycleEnd(J9HookInterface** hook, uintptr_t eventN
 
 	if ((OMR_GC_CYCLE_TYPE_GLOBAL == event->cycleType) && (FIXUP_NONE != event->fixHeapForWalkReason)) {
 		uint64_t fixupDuration = event->fixHeapForWalkTime;
-		getTagTemplate(fixupTagTemplate, sizeof(fixupTagTemplate), omrtime_current_time_millis());
+		getTagTemplate(fixupTagTemplate, sizeof(fixupTagTemplate), omrtime_hires_clock());
 		writer->formatAndOutput(env, 0, "<heap-fixup timems=\"%llu.%03llu\" reason=\"%s\"  %s />", fixupDuration / 1000, fixupDuration % 1000, getHeapFixupReasonString(event->fixHeapForWalkReason), fixupTagTemplate);
 	}
 
@@ -598,7 +598,7 @@ MM_VerboseHandlerOutput::handleExclusiveStart(J9HookInterface** hook, uintptr_t 
 	getThreadName(escapedLastResponderName,sizeof(escapedLastResponderName),lastResponder);
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	if (!deltaTimeSuccess) {
 		writer->formatAndOutput(env, 0, "<warning details=\"clock error detected, following timing may be inaccurate\" />");
@@ -627,7 +627,7 @@ MM_VerboseHandlerOutput::handleExclusiveEnd(J9HookInterface** hook, uintptr_t ev
 
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	if (!deltaTimeSuccess) {
 		writer->formatAndOutput(env, 0, "<warning details=\"clock error detected, following timing may be inaccurate\" />");
@@ -658,7 +658,7 @@ MM_VerboseHandlerOutput::handleSystemGCStart(J9HookInterface** hook, uintptr_t e
 
 	manager->setLastSystemGCTime(currentTime);
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	if (!deltaTimeSuccess) {
 		writer->formatAndOutput(env, 0, "<warning details=\"clock error detected, following timing may be inaccurate\" />");
@@ -677,7 +677,7 @@ MM_VerboseHandlerOutput::handleSystemGCEnd(J9HookInterface** hook, uintptr_t eve
 	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<sys-end %s />", tagTemplate);
 	writer->flush(env);
@@ -714,7 +714,7 @@ MM_VerboseHandlerOutput::handleAllocationFailureStart(J9HookInterface** hook, ui
 	bool deltaTimeSuccess = getTimeDeltaInMicroSeconds(&deltaTime, previousTime, currentTime);
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	if (!deltaTimeSuccess) {
 		writer->formatAndOutput(env, 0, "<warning details=\"clock error detected, following timing may be inaccurate\" />");
@@ -746,7 +746,7 @@ MM_VerboseHandlerOutput::handleFailedAllocationCompleted(J9HookInterface** hook,
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[200];
 	enterAtomicReportingBlock();
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_hires_clock());
 	uintptr_t id = manager->getIdAndIncrement();
 	uintptr_t bytesRequested = event->bytesRequested;
 	if (TRUE == event->succeeded) {
@@ -768,7 +768,7 @@ MM_VerboseHandlerOutput::handleAllocationFailureEnd(J9HookInterface** hook, uint
 	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 
 	const bool succeeded = allocDescription->getAllocationSucceeded();
 	const char *successString = succeeded? "true" : "false";
@@ -804,7 +804,7 @@ MM_VerboseHandlerOutput::handleAcquiredExclusiveToSatisfyAllocation(J9HookInterf
 	uintptr_t indentLevel = _manager->getIndentLevel();
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, indentLevel, "<event %s>", tagTemplate);
 	writer->formatAndOutput(env, indentLevel + 1, "<warning details=\"exclusive access acquired to satisfy allocation\" />");
@@ -910,7 +910,7 @@ MM_VerboseHandlerOutput::handleGCStart(J9HookInterface** hook, uintptr_t eventNu
 	MM_CollectionStatistics *stats = (MM_CollectionStatistics *)event->stats;
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getCurrentCycleType(env), env->_cycleState->_verboseContextID, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getCurrentCycleType(env), env->_cycleState->_verboseContextID, omrtime_hires_clock());
 
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<gc-start %s>", tagTemplate);
@@ -950,7 +950,7 @@ MM_VerboseHandlerOutput::handleGCEnd(J9HookInterface** hook, uintptr_t eventNum,
 	getTagTemplateWithDuration(	tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(),
 								getCurrentCycleType(env), env->_cycleState->_verboseContextID,
 								durationInMicroseconds, userTimeInMicroseconds, systemTimeInMicroseconds,
-								omrtime_current_time_millis(), stallTimeInMicroseconds);
+								omrtime_hires_clock(), stallTimeInMicroseconds);
 								
 	uintptr_t activeThreads = env->getExtensions()->dispatcher->activeThreadCount();
 
@@ -974,7 +974,7 @@ MM_VerboseHandlerOutput::handleConcurrentStart(J9HookInterface** hook, UDATA eve
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	UDATA contextId = stats->_cycleID;
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getConcurrentTypeString(stats->_concurrentCycleType), contextId, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getConcurrentTypeString(stats->_concurrentCycleType), contextId, omrtime_hires_clock());
 
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<concurrent-start %s>", tagTemplate);
@@ -995,7 +995,7 @@ MM_VerboseHandlerOutput::handleConcurrentEnd(J9HookInterface** hook, UDATA event
 	UDATA contextId = stats->_cycleID;
 	char tagTemplate[200];
 	const char* reasonForTermination = getConcurrentTerminationReason(stats);
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getConcurrentTypeString(stats->_concurrentCycleType), contextId, omrtime_current_time_millis(), reasonForTermination);
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), getConcurrentTypeString(stats->_concurrentCycleType), contextId, omrtime_hires_clock(), reasonForTermination);
 
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<concurrent-end %s>", tagTemplate);
@@ -1057,7 +1057,7 @@ MM_VerboseHandlerOutput::outputHeapResizeInfo(MM_EnvironmentBase *env, uintptr_t
 		reasonString = "unknown";
 	}
 
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_hires_clock());
 
 	writer->formatAndOutput(env, indent, "<heap-resize id=\"%zu\" type=\"%s\" space=\"%s\" amount=\"%zu\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" %s />", id, resizeTypeName, getSubSpaceType(subSpaceType), resizeAmount, resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString, tagTemplate);
 	writer->flush(env);
@@ -1083,7 +1083,7 @@ MM_VerboseHandlerOutput::outputCollectorHeapResizeInfo(MM_EnvironmentBase *env, 
 		reasonString = "unknown";
 	}
 
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_hires_clock());
 
 	writer->formatAndOutput(env, indent, "<heap-resize type=\"%s\" space=\"%s\" amount=\"%zu\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" />", resizeTypeName, getSubSpaceType(subSpaceType), resizeAmount, resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString);
 }
@@ -1105,7 +1105,7 @@ MM_VerboseHandlerOutput::handleExcessiveGCRaised(J9HookInterface** hook, uintptr
 	uintptr_t indentLevel = _manager->getIndentLevel();
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), _manager->getIdAndIncrement(), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, indentLevel, "<event %s>", tagTemplate);
 
@@ -1178,7 +1178,7 @@ MM_VerboseHandlerOutput::handleGCOPOuterStanzaStart(MM_EnvironmentBase* env, con
 	}
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), type ,contextID, duration, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), type ,contextID, duration, omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<gc-op %s>", tagTemplate);
 }
 

--- a/gc/verbose/VerboseWriterFileLogging.cpp
+++ b/gc/verbose/VerboseWriterFileLogging.cpp
@@ -118,7 +118,7 @@ MM_VerboseWriterFileLogging::initializeTokens(MM_EnvironmentBase *env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	char pidBuffer[64];
 	
-	_tokens = omrstr_create_tokens(omrtime_current_time_millis());
+	_tokens = omrstr_create_tokens(omrtime_hires_clock());
 	if (_tokens == NULL) {
 		return false;
 	}

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -275,7 +275,7 @@ MM_VerboseHandlerOutputStandard::handleGCOPStanza(MM_EnvironmentBase* env, const
 	}
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), type ,contextID, duration, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), type ,contextID, duration, omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<gc-op %s />", tagTemplate);
 	writer->flush(env);
 }
@@ -502,7 +502,7 @@ MM_VerboseHandlerOutputStandard::handleScavengePercolate(J9HookInterface** hook,
 	MM_VerboseWriterChain* writer = manager->getWriterChain();
 
 	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_hires_clock());
 	enterAtomicReportingBlock();
 	writer->formatAndOutput(env, 0, "<percolate-collect id=\"%zu\" from=\"%s\" to=\"%s\" reason=\"%s\" %s/>", manager->getIdAndIncrement(), "nursery", "global", getPercolateReasonAsString((PercolateReason)event->reason), tagTemplate);
 	writer->flush(env);
@@ -664,7 +664,7 @@ MM_VerboseHandlerOutputStandard::handleConcurrentKickoff(J9HookInterface** hook,
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[200];
 	enterAtomicReportingBlock();
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<concurrent-kickoff %s>", tagTemplate);
 
 	const char* reasonString = getConcurrentKickoffReason(eventData);
@@ -726,7 +726,7 @@ MM_VerboseHandlerOutputStandard::handleConcurrentHalted(J9HookInterface** hook, 
 
 	char tagTemplate[200];
 	enterAtomicReportingBlock();
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<concurrent-halted %s>", tagTemplate);
 
 	handleConcurrentHaltedInternal(env, eventData);
@@ -787,7 +787,7 @@ MM_VerboseHandlerOutputStandard::handleConcurrentCollectionStart(J9HookInterface
 
 	char tagTemplate[200];
 	enterAtomicReportingBlock();
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), event->contextid, omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), event->contextid, omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<concurrent-global-final %s intervalms=\"%llu.%03llu\" >",
 		tagTemplate, deltaTime / 1000, deltaTime % 1000);
 	handleConcurrentCollectionStartInternal(env, eventData);
@@ -826,7 +826,7 @@ MM_VerboseHandlerOutputStandard::handleConcurrentAborted(J9HookInterface** hook,
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	char tagTemplate[100];
 	enterAtomicReportingBlock();
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_current_time_millis());
+	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), omrtime_hires_clock());
 	writer->formatAndOutput(env, 0, "<concurrent-aborted %s>", tagTemplate);
 
 	const char* reason;


### PR DESCRIPTION
The omrtime_current_time_millis() uses UNIX gettimeofday() function, and is therefore non-monotonic and error-prone.
We turn to use monotonic omrtime_hires_clock() function call for gc files.

Issue: #7051