### PR TITLE
(0.44) Evaluate constant byteLenNode of arrayCopyChild

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13497,6 +13497,7 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
       // We need to decide direction of array copy at runtime.
       if (isConstantByteLen)
          {
+         byteLenReg = cg->gprClobberEvaluate(byteLenNode);
          generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
          }
@@ -13506,12 +13507,6 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
 
 
       TR::Register *checkBoundReg = srm->findOrCreateScratchRegister();
-      if (byteLenReg == NULL)
-         {
-         TR_ASSERT_FATAL(isConstantByteLen, "byteLenNode can be not evaluated only when we have constant length");
-         byteLenReg = cg->allocateRegister();
-         genLoadLongConstant(cg, node, byteLenNode->getConst<int64_t>(), byteLenReg);
-         }
       cursor = generateRXInstruction(cg, TR::InstOpCode::LA, node, checkBoundReg, generateS390MemoryReference(byteSrcReg, byteLenReg, 0, cg));
       iComment("nextPointerToLastElement=byteSrcPointer+lengthInBytes");
 


### PR DESCRIPTION
In case of constant length array copy code, a length of bytes to be copied would be loaded into register in case we need to perform a test to check for destructive region copies and perform destructive array copy. We need to make sure that byteLength node is evaluated before the internal control flow starts. We found an issue where downstream consumer of primitive arraycopy sequnece generator needed byteLenReg and as the constant value was loaded only in case we fail absolute test for forward copy check, we ended up in scenario where it reads a value from array using length which consists of garbage. This commit fixes the issue and in case, we do not know the direction for array copy, it evaluates bytelength node before internal control flow starts.

Port of https://github.com/eclipse/omr/pull/7275 for 0.44