### PR TITLE
(0.46) AArch64: Handle shift amount 0

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1576,9 +1576,17 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
    if (secondOp == TR::iconst)
       {
       int32_t value = secondChild->getInt();
-      if (value == 0 && firstChild->getReferenceCount() == 1)
+      if (value == 0)
          {
-         trgReg = srcReg;
+         if (firstChild->getReferenceCount() == 1)
+            {
+            trgReg = srcReg;
+            }
+         else
+            {
+            trgReg = cg->allocateRegister();
+            generateMovInstruction(cg, node, trgReg, srcReg, is64bit);
+            }
          }
       else
          {


### PR DESCRIPTION
This code fixes shiftHelper() in AArch64 codegen.
It generates a mov instruction when the shift amount is 0 and the reference count of the first child of a shift node is larger than 1.

Original PR: https://github.com/eclipse/omr/pull/7343