### PR TITLE
(0.46.0) Revert GRA changes to avoid throughput regressions

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -832,8 +832,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"GCRresetCount=",       "R<nnn>\tthe value to which the counter is reset to after being tripped by guarded counting recompilations (positive value)",
     TR::Options::setCount, offsetof(OMR::Options,_GCRResetCount), 0, "F%d"},
    {"generateCompleteInlineRanges", "O\tgenerate meta data ranges for each change in inliner depth", SET_OPTION_BIT(TR_GenerateCompleteInlineRanges), "F"},
-   {"graFreqThresholdAtWarm=", "O<nnn>\tgra threshold for block frequency for opt level less of equal to warm",
-        TR::Options::set32BitNumeric, offsetof(OMR::Options, _graFreqThresholdAtWarm), 500, "F%d"},
    {"help",               " \tdisplay this help information", TR::Options::helpOption, 0, 0, "F", NOT_IN_SUBSET},
    {"help=",              " {regex}\tdisplay help for options whose names match {regex}", TR::Options::helpOption, 1, 0, "F", NOT_IN_SUBSET},
    {"highCodeCacheOccupancyBCount=", "R<nnn>\tthe initial invocation count used during high code cache occupancy for methods with loops",
@@ -2684,7 +2682,6 @@ OMR::Options::jitPreProcess()
    _alwaysWorthInliningThreshold = 15;
    _maxLimitedGRACandidates = TR_MAX_LIMITED_GRA_CANDIDATES;
    _maxLimitedGRARegs = TR_MAX_LIMITED_GRA_REGS;
-   _graFreqThresholdAtWarm = 500;
    _counterBucketGranularity = 2;
    _minCounterFidelity = INT_MIN;
    _lastIpaOptTransformationIndex = INT_MAX;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1468,7 +1468,6 @@ public:
       _insertGCRTrees = false;
       _maxLimitedGRACandidates = 0;
       _maxLimitedGRARegs = 0;
-      _graFreqThresholdAtWarm = 0;
       _enableGPU = 0;
       _isAOTCompile = false;
       _jProfilingMethodRecompThreshold = 0;
@@ -1823,7 +1822,6 @@ public:
    int32_t getAlwaysWorthInliningThreshold() const { return _alwaysWorthInliningThreshold; }
    int32_t getMaxLimitedGRACandidates()   { return _maxLimitedGRACandidates; }
    int32_t getMaxLimitedGRARegs()         { return _maxLimitedGRARegs; }
-   int32_t getGRAFreqThresholdAtWarm()    { return _graFreqThresholdAtWarm; }
    int32_t getNumLimitedGRARegsWithheld();
 
    int32_t getProfilingCompNodecountThreshold()  { return _profilingCompNodecountThreshold; }
@@ -2483,7 +2481,6 @@ protected:
 
    int32_t                     _maxLimitedGRACandidates;
    int32_t                     _maxLimitedGRARegs;
-   int32_t                     _graFreqThresholdAtWarm;
 
    int32_t                     _enableGPU;
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -2733,12 +2733,11 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
             if (paramCursor->getLinkageRegisterIndex() >= 0)
                rc->addAllBlocks();
             }
-
-         i = paramCursor->getLiveLocalIndex();
-         autoAndParmLiveLocalIndex.set(i);
-         registerCandidateByIndex[i] = rc;
          }
 
+      i = paramCursor->getLiveLocalIndex();
+      autoAndParmLiveLocalIndex.set(i);
+      registerCandidateByIndex[i] = rc;
       paramCursor = paramIterator.getNext();
       }
 

--- a/compiler/optimizer/GlobalRegisterAllocator.hpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.hpp
@@ -169,12 +169,16 @@ public:
 
 private:
 
+   void                findIfThenRegisterCandidates();
+   void                findLoopsAndCorrespondingAutos(TR_StructureSubGraphNode *, vcount_t, SymRefCandidateMap &);
    void                findLoopsAndAutosNoStructureInfo(vcount_t visitCount, TR::RegisterCandidate **registerCandidates);
    void                initializeControlFlowInfo();
+   virtual void        markAutosUsedIn(TR::Node *, TR::Node *, TR::Node *, TR::Node **, TR::Block *, List<TR::Block> *, vcount_t, int32_t, SymRefCandidateMap &, TR_BitVector *, TR_BitVector *, bool);
    void                signExtendAllDefNodes(TR::Node *, List<TR::Node> *);
    void                findSymsUsedInIndirectAccesses(TR::Node *, TR_BitVector *, TR_BitVector *, bool);
 
    void                offerAllAutosAndRegisterParmAsCandidates(TR::Block **, int32_t, bool onlySelectedCandidates = false);
+   void                offerAllFPAutosAndParmsAsCandidates(TR::Block **, int32_t);
 
    bool                allocateForSymRef(TR::SymbolReference *symRef);
    bool                allocateForType(TR::DataType dt);
@@ -219,7 +223,8 @@ private:
    void appendStoreToBlock(TR::SymbolReference *storeSymRef, TR::SymbolReference *loadSymRef, TR::Block *block, TR::Node *node);
    */
 protected:
-   TR::Block *         createNewSuccessorBlock(TR::Block *, TR::Block *, TR::TreeTop *, TR::Node *, TR::RegisterCandidate * rc);
+   void                findLoopAutoRegisterCandidates();
+   TR::Block *          createNewSuccessorBlock(TR::Block *, TR::Block *, TR::TreeTop *, TR::Node *, TR::RegisterCandidate * rc);
    void                appendGotoBlock(TR::Block *gotoBlock, TR::Block *curBlock);
    void                transformBlock(TR::TreeTop *);
    bool                isTypeAvailable(TR::SymbolReference *symref);


### PR DESCRIPTION
This is a cherry-pick of the two commits in https://github.com/eclipse/omr/pull/7354.

Rationale: PR https://github.com/eclipse/omr/pull/7303 added changes to improve the overhead of the global register allocator and PR https://github.com/eclipse/omr/pull/7328 fixed a bug in the newly introduced code.
Performance experiments have shown that while these changes reduce the CPU consumed by the JIT compilation threads by ~7.5%, they also cause throughput regressions on Daytrader (~1%), AcmeAIREE8 (~2%) and Ilog (~1%) benchmarks.
