### PR TITLE
(0.46) Passing unsuccessful state to GC cycle end event

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4435,6 +4435,11 @@ void
 MM_Scavenger::reportGCCycleFinalIncrementEnding(MM_EnvironmentStandard *env)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	uintptr_t cycleType = env->_cycleState->_type;
+	/* set OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL bit in the cycleType of CycleEnd event in scavenge backout case */
+	if (env->getExtensions()->isScavengerBackOutFlagRaised()) {
+		cycleType |= OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL;
+	}
 
 	MM_CommonGCData commonData;
 
@@ -4444,7 +4449,7 @@ MM_Scavenger::reportGCCycleFinalIncrementEnding(MM_EnvironmentStandard *env)
 		omrtime_hires_clock(),
 		J9HOOK_MM_OMR_GC_CYCLE_END,
 		_extensions->getHeap()->initializeCommonGCData(env, &commonData),
-		env->_cycleState->_type,
+		cycleType,
 		omrgc_condYieldFromGC
 	);
 }

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -132,6 +132,12 @@ typedef enum MM_ScavengeScanReason {
 #define OMR_GC_CYCLE_TYPE_GLOBAL      1
 #define OMR_GC_CYCLE_TYPE_SCAVENGE    2
 #define OMR_GC_CYCLE_TYPE_EPSILON	 6
+/**
+ * This bit represents the state to abort a cycle. It is only used in the cycleType of CycleEnd event.
+ * MM_CycleState->_type has uintptr_t type. This code still needs to be supported on 32-bit platforms,
+ * which will require the bit to fit in a 32 bit word.
+ */
+#define OMR_GC_CYCLE_TYPE_STATE_UNSUCCESSFUL 0x80000000
 
 /* Core allocation flags defined for OMR are < OMR_GC_ALLOCATE_OBJECT_LANGUAGE_DEFINED_BASE */
 #define OMR_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE 0x0


### PR DESCRIPTION
 - define new unsuccessful state via 31bit of cycleType (bit31=1 cycle end unsuccessfully(abort), bit31=0 cycle end successfully)
 - only passing the state to GC cycle end event via cycleType
 - GC cycle end hooks can identify cycle abort case via the unsuccessful state.

Cherry pick https://github.com/eclipse/omr/pull/7353