### PR TITLE
Fix underestimation of array length in constrainAload (0.48)

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1962,7 +1962,7 @@ TR::Node *constrainAload(OMR::ValuePropagation *vp, TR::Node *node)
                         if (elementSize != 0)
                            {
                            constraint = TR::VPClass::create(vp, (TR::VPClassType*)constraint, NULL, NULL,
-                                 TR::VPArrayInfo::create(vp, 0, elementSize == 0 ? TR::getMaxSigned<TR::Int32>() : TR::getMaxSigned<TR::Int32>()/elementSize, elementSize),
+                                 TR::VPArrayInfo::create(vp, 0, TR::Compiler->om.maxArraySizeInElements(elementSize, vp->comp()), elementSize),
                                  TR::VPObjectLocation::create(vp, TR::VPObjectLocation::NotClassObject));
                            }
                         }


### PR DESCRIPTION
To this point, VP has constrained the length of an array in `constrainAload` to be between 0 and `TR::getMaxSigned<TR::Int32>() / elementSize` elements long. This was likely a due to a historical limitation. Since arrays can be longer than `TR::getMaxSigned<TR::Int32>()` bytes, if such an array were copied, it would fail the `ArrayCopyBNDCHK`, causing erroneous removal of trees that would prevent the copy from being performed. I discussed my findings during my investigation of this issue in a series of comments in [openj9 #19247](https://github.com/eclipse-openj9/openj9/issues/19247#issuecomment-2134018832).

This PR increases the high bound of the constraint on the length of an array in `constrainAload` by using `J9::ObjectModel::maxArraySizeInElements()` instead, which produces a better upper bound based on the size of the heap. We already use this method in other parts of VP, like [constrainArraylength](https://github.com/eclipse/omr/blob/e136a7a853c0afb4e0a392b68158aa4d3827f671/compiler/optimizer/VPHandlers.cpp#L4878).

This PR ports [omr #7461](https://github.com/eclipse/omr/pull/7461) to the 0.48 release.

Fixes: [openj9 #19247](https://github.com/eclipse-openj9/openj9/issues/19247), [openj9 #19403](https://github.com/eclipse-openj9/openj9/issues/19403), [openj9 #15500 (most likely)](https://github.com/eclipse-openj9/openj9/issues/15500)