### PR TITLE
(0.49.0) Fix syncTempTrampolines when startPC returns 0

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -682,7 +682,15 @@ OMR::CodeCache::syncTempTrampolines()
             {
             void *newPC = (void *) TR::Compiler->mtd.startPC(entry->_info._resolved._method);
             void *trampoline = entry->_info._resolved._currentTrampoline;
-            if (trampoline && entry->_info._resolved._currentStartPC != newPC)
+            bool forceCreateTrampoline = false;
+
+            if (reinterpret_cast<intptr_t>(newPC) == 0)
+               {
+               newPC = entry->_info._resolved._currentStartPC;
+               forceCreateTrampoline = true;
+               }
+
+            if (trampoline && (forceCreateTrampoline || (entry->_info._resolved._currentStartPC != newPC)))
                {
                self()->createTrampoline(trampoline,
                                         newPC,
@@ -709,6 +717,11 @@ OMR::CodeCache::syncTempTrampolines()
             {
             CodeCacheHashEntry *entry = syncBlock->_hashEntryArray[entryIdx];
             void *newPC = (void *) TR::Compiler->mtd.startPC(entry->_info._resolved._method);
+
+            if (reinterpret_cast<intptr_t>(newPC) == 0)
+               {
+               newPC = entry->_info._resolved._currentStartPC;
+               }
 
             // call the codegen to perform the trampoline code modification
             self()->createTrampoline(entry->_info._resolved._currentTrampoline,


### PR DESCRIPTION
When syncing temporary trampolines, there is a call to startPC with the callee method to try and get the start PC. If the latest compilation of that method failed, startPC returns zero which is not a real start PC and can not be used as a target for a trampoline. Attempting to do so will cause an error.

This change adds error checking when trying to sync trampolines. When a start PC of zero is returned from the call to startPC, the previous start PC is used instead.

Backport of https://github.com/eclipse-omr/omr/pull/7550