### PR TITLE
(0.51) Print noResumableTrapHandler and disableTraps options if set

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4033,6 +4033,12 @@ OMR::Options::printOptions(const char *options, const char *envOptions)
    TR_Debug::dumpOptions(optionsType, options, envOptions, self(), _jitOptions, TR::Options::_feOptions, _feBase, _fe);
    if (_aggressivenessLevel > 0)
        TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "aggressivenessLevel=%d", _aggressivenessLevel);
+
+   if (self()->getOption(TR_NoResumableTrapHandler))
+       TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "noResumableTrapHandler");
+
+   if (self()->getOption(TR_DisableTraps))
+       TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "disableTraps");
    }
 
 


### PR DESCRIPTION
cherry pick https://github.com/eclipse-omr/omr/pull/7668

-------

Print noResumableTrapHandler and disableTraps options in verbose logs if they are set. With https://github.com/eclipse-openj9/openj9/pull/21154, noResumableTrapHandler could be set implicitly by the JVM.