### PR TITLE
Eliminate usage of getCallCount()

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1700,8 +1700,6 @@ uint32_t      OMR::Options::_cpuExpensiveCompThreshold = 0; // not initialized
 int32_t       OMR::Options::_deterministicMode = -1; // -1 means we're not in any deterministic mode
 int32_t       OMR::Options::_maxPeekedBytecodeSize = 100000;
 
-int32_t       OMR::Options::INLINE_failedToDevirtualize          = 0;
-int32_t       OMR::Options::INLINE_failedToDevirtualizeInterface = 0;
 int32_t       OMR::Options::INLINE_fanInCallGraphFactor          = 90;
 int32_t       OMR::Options::INLINE_calleeToBig                   = 0;
 int32_t       OMR::Options::INLINE_calleeToDeep                  = 0;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1918,8 +1918,6 @@ public:
    static int32_t _queueWeightThresholdForStarvation;
 
 
-   static int32_t INLINE_failedToDevirtualize;
-   static int32_t INLINE_failedToDevirtualizeInterface;
    static int32_t INLINE_fanInCallGraphFactor;
    static int32_t INLINE_calleeToBig;
    static int32_t INLINE_calleeToDeep;

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4163,14 +4163,6 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
    if(callsite->numTargets())    //if we still have targets at this point we can return true as we would have in the loop
       return;
 
-   if ( getUtil()->getCallCount(callNode) > 0)
-      {
-      if (callsite->isInterface())
-         TR::Options::INLINE_failedToDevirtualize ++;
-      else
-         TR::Options::INLINE_failedToDevirtualizeInterface ++;
-      }
-
    if (callsite->numTargets()>0 && callsite->getTarget(0) && !callsite->getTarget(0)->_calleeMethod && comp()->trace(OMR::inlining))
       {
       traceMsg(comp(), "inliner: method is unresolved: %s into %s\n", callsite->_interfaceMethod->signature(trMemory()), tracer()->traceSignature(callStack->_methodSymbol));


### PR DESCRIPTION
getCallCount() is mainly used in the OpenJ9 downstream project to derive block frequency.
OpenJ9 plans to deprecate its usage and therefore its presence in OMR needs to be eliminated.