### PR TITLE
[0.53.0] Correct handling of contigarraylenth of known object in VP

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4803,14 +4803,6 @@ TR::Node *constrainArraylength(OMR::ValuePropagation *vp, TR::Node *node)
 
    vp->getArrayLengthLimits(constraint, lowerBoundLimit, upperBoundLimit, elementSize, isKnownObj);
 
-   // If this is a known array object, we definitely know its length
-   //
-   if (isKnownObj)
-      {
-      vp->replaceByConstant(node, TR::VPIntConst::create(vp, lowerBoundLimit), isGlobal);
-      return node;
-      }
-
    // If the element size is still not known, try to get it from the node or
    // from the signature, and then propagate it back down to the object ref.
    //


### PR DESCRIPTION
The Value Propagation `constrainArraylength` method handles not only `TR::arraylength`, but `TR::contigarraylength` and `TR::discontigarraylength` as well.  If the operand of the operation is a known object, code in this VP handler was always folding the value of the operation to be equal to the length of the array, but that is only correct in general for a `TR::arraylength` operation.

This change removes special handling of known objects, as the lower bound and upper bound on the array length will be equal in that case, and there is already code that correctly handles the case where the bounds on the array length are equal for all three of `TR::arraylength`, `TR::contigarraylength` and `TR::discontigarraylength`.

Fixes:  eclipse-openj9/openj9#21904

Port of [OMR Pull Request 7790](https://github.com/eclipse-omr/omr/pull/7790) to v0.53.0-release branch.