### PR TITLE
Add exclusive access to VM stat for gc to be used in JFR

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -42,6 +42,7 @@
 #include "SweepStats.hpp"
 #include "WorkPacketStats.hpp"
 #include "WorkStack.hpp"
+#include "CollectionStatistics.hpp"
 
 class MM_AllocationContext;
 class MM_AllocateDescription;
@@ -157,6 +158,8 @@ public:
 	MM_MarkStats _markStats;
 
 	MM_RootScannerStats _rootScannerStats; /**< Per thread stats to track the performance of the root scanner */
+
+	MM_CollectionStatistics _gcCollectionStats;
 
 	const char * _lastSyncPointReached; /**< string indicating latest sync point reached by this associated env's thread */
 

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4296,6 +4296,8 @@ MM_Scavenger::mainThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_AllocateD
 	GC_OMRVMInterface::flushCachesForGC(env);
 
 	if (firstIncrement)	{
+		_extensions->scavengerStats._gcCount += 1;
+
 		if (_extensions->processLargeAllocateStats) {
 			processLargeAllocateStatsBeforeGC(env);
 		}
@@ -4834,7 +4836,6 @@ MM_Scavenger::internalGarbageCollect(MM_EnvironmentBase *envBase, MM_MemorySubSp
 
 	_extensions->heap->getPercolateStats()->incrementScavengesSincePercolate();
 
-	_extensions->scavengerStats._gcCount += 1;
 	env->_cycleState->_activeSubSpace = subSpace;
 	_collectorExpandedSize = 0;
 

--- a/gc/stats/CollectionStatistics.hpp
+++ b/gc/stats/CollectionStatistics.hpp
@@ -44,6 +44,10 @@ public:
 	uint64_t  _startTime;		/**< Collection start time */
 	uint64_t  _endTime;			/**< Collection end time */
 	uint64_t  _stallTime;		/**< Collection stall time */
+	uint64_t  _exclusiveStartTime;		/**< Exclusive VM access start time */
+	uint64_t  _exclusiveEndTime;		/**< Exclusive VM access end time */
+	uint64_t  _maxExclusiveTime;		/**< Longest exclusive access for this GC cycle */
+	uint64_t  _totalTime;				/**< Total time spent for this GC cycle */
 
 	omrthread_process_time_t _startProcessTimes; /**< Process (Kernel and User) start time(s) */
 	omrthread_process_time_t _endProcessTimes;   /**< Process (Kernel and User) end time(s) */
@@ -63,6 +67,10 @@ public:
 		,_startTime(0)
 		,_endTime(0)
 		,_stallTime(0)
+		,_exclusiveStartTime(0)
+		,_exclusiveEndTime(0)
+		,_maxExclusiveTime(0)
+	  	,_totalTime(0)
 		,_startProcessTimes()
 		,_endProcessTimes()
 		,_cpuUtilStats()


### PR DESCRIPTION
This change adds some stats based around exclusive access to the VM for the GC.