### PR TITLE
[0.54.0] Track distinct live commoned loads of locals for Store Sinking

### DIFF
--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -766,6 +766,20 @@ class TR_LiveVariableInformation
    int32_t numNodes()                { return _numNodes; }
 
    TR_BitVector *liveCommonedLoads() { return _liveCommonedLoads; }
+
+   /**
+    * The number of distinct commoned loads that are live for a particular
+    * local variable during a backwards tree walk.
+    * \param localIdx The index of a local variable
+    * \returns The number of distinct commoned loads of the local variable
+    *          that are live, or zero if the number of distinct commoned
+    *          loads is not being tracked.
+    */
+   int32_t numDistinctCommonedLoads(int32_t localIdx)
+      {
+      return (_distinctCommonedLoads == NULL) ? 0 : _distinctCommonedLoads[localIdx];
+      }
+
    void createGenAndKillSetCaches();
    void initializeGenAndKillSetInfo(TR_BitVector **genSetInfo, TR_BitVector **killSetInfo,
                                     TR_BitVector **exceptionGenSetInfo, TR_BitVector **exceptionKillSetInfo);
@@ -815,6 +829,20 @@ class TR_LiveVariableInformation
 
    // this bit vector tracks which commoned loads are currently live
    TR_BitVector   *_liveCommonedLoads;
+
+   /**
+    * A \ref TR::NodeChecklist that is used to keep track of whether a particular
+    * commoned \ref TR::Node for the load of a local variable has already been
+    * encountered during a backwards tree walk.
+    */
+   TR::NodeChecklist   *_seenCommonedNodeForLoadOfLocal;
+
+   /**
+    * An array that is used to keep track of the number of distinct commoned
+    * loads of a local variable that are live at a given point in a backwards
+    * tree walk.
+    */
+   int32_t        *_distinctCommonedLoads;
    };
 
 

--- a/compiler/optimizer/LiveVariableInformation.cpp
+++ b/compiler/optimizer/LiveVariableInformation.cpp
@@ -54,10 +54,10 @@ class TR_Structure;
 namespace TR { class Optimizer; }
 
 TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
-			                               TR::Optimizer *optimizer,
-			                               TR_Structure     *rootStructure,
-			                               bool              splitLongs,
-			                               bool              includeParms,
+                                                       TR::Optimizer *optimizer,
+                                                       TR_Structure     *rootStructure,
+                                                       bool              splitLongs,
+                                                       bool              includeParms,
                                                        bool              ignoreOSRUses)
    : _compilation(c), _trMemory(c->trMemory()), _ignoreOSRUses(ignoreOSRUses)
    {
@@ -77,6 +77,8 @@ TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
 
    _haveCachedGenAndKillSets = false;
    _liveCommonedLoads = NULL;
+   _seenCommonedNodeForLoadOfLocal = NULL;
+   _distinctCommonedLoads = NULL;
    }
 
 void TR_LiveVariableInformation::collectLiveVariableInformation()
@@ -413,10 +415,10 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
       {
       if (movingForwardThroughTrees)
          traceMsg(comp(), "         Looking forward for uses in node %p has visitCount = %d and comp() visitCount = %d\n",
-		  node, node->getVisitCount(), visitCount);
+                  node, node->getVisitCount(), visitCount);
       else
          traceMsg(comp(), "         Looking backward for uses in node %p has future use count = %d and reference count = %d\n",
-		  node, node->getFutureUseCount(), node->getReferenceCount());
+                  node, node->getFutureUseCount(), node->getReferenceCount());
       }
 
    uint16_t localIndex = INVALID_LIVENESS_INDEX;
@@ -468,6 +470,26 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
             if (traceLiveVarInfo())
                traceMsg(comp(), "            not first reference\n");
 
+            if (_liveCommonedLoads != NULL && local != NULL)
+               {
+               if (_seenCommonedNodeForLoadOfLocal == NULL)
+                  {
+                  _seenCommonedNodeForLoadOfLocal = new (trStackMemory()) TR::NodeChecklist(comp());
+                  _distinctCommonedLoads = (int32_t *) comp()->trMemory()->allocateStackMemory(_numLocals * sizeof(int32_t));
+                  memset(_distinctCommonedLoads, 0x0, _numLocals * sizeof(int32_t));
+                  }
+
+               // Has this load of a local variable been encountered before in this backwards
+               // tree walk?  If not, add the node to the checklist and bump the number of distinct
+               // commoned loads of the local variable.
+               //
+               if (!_seenCommonedNodeForLoadOfLocal->contains(node))
+                  {
+                  _seenCommonedNodeForLoadOfLocal->add(node);
+                  _distinctCommonedLoads[localIndex] = _distinctCommonedLoads[localIndex] + 1;
+                  }
+               }
+
             // traversal should either end here (for regular traversal) or track that we're below a commoned node
             if (visitEntireTree)
                belowCommonedNode = true;
@@ -477,11 +499,55 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
          else
             {
             if (traceLiveVarInfo())
-               traceMsg(comp(), "            first reference\n");
+               traceMsg(comp(), "            first reference, ");
 
-            // if this is a load, clear it in liveCommonedLoads if we've been asked to track them
+            bool otherReferencesStillLive = false;
+
+            // if this is a load, and there are no other live commoned loads of the local,
+            // clear it in liveCommonedLoads if we've been asked to track them
             if (_liveCommonedLoads != NULL && local != NULL)
-               _liveCommonedLoads->reset(localIndex);
+               {
+               if (_seenCommonedNodeForLoadOfLocal != NULL)
+                  {
+                  // If we've encountered a commoned reference to this node, decrease
+                  // the number of distinct commoned references of the local that are
+                  // are still live.  If there are no more live commoned references to
+                  // the local, remove it from _liveCommonedLoads
+                  //
+                  if (_seenCommonedNodeForLoadOfLocal->contains(node))
+                     {
+                     int32_t numDistinctCommonedLoads = _distinctCommonedLoads[localIndex];
+                     _distinctCommonedLoads[localIndex] = numDistinctCommonedLoads - 1;
+
+                     _seenCommonedNodeForLoadOfLocal->remove(node);
+
+                     if (numDistinctCommonedLoads == 1)
+                        {
+                        _liveCommonedLoads->reset(localIndex);
+                        }
+                     else
+                        {
+                        otherReferencesStillLive = true;
+                        }
+                     }
+                  }
+               else
+                  {
+                  _liveCommonedLoads->reset(localIndex);
+                  }
+               }
+
+            if (traceLiveVarInfo())
+               {
+               if (otherReferencesStillLive)
+                  {
+                  traceMsg(comp(), "but other commoned references to this sym are still live\n");
+                  }
+               else
+                  {
+                  traceMsg(comp(), "and this was the first of all commoned references to this sym\n");
+                  }
+               }
             }
          }
 
@@ -522,6 +588,19 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
             if (traceLiveVarInfo())
                traceMsg(comp(), "              Marking %d as live commoned load\n", localIndex);
             _liveCommonedLoads->set(localIndex);
+
+            if (!movingForwardThroughTrees && _seenCommonedNodeForLoadOfLocal != NULL)
+               {
+               // Has this load of a local variable been encountered before in this backwards
+               // tree walk?  If not, add the node to the checklist and bump the number of distinct
+               // commoned loads of the local variable.
+               //
+               if (!_seenCommonedNodeForLoadOfLocal->contains(node))
+                  {
+                  _distinctCommonedLoads[localIndex] = _distinctCommonedLoads[localIndex] + 1;
+                  _seenCommonedNodeForLoadOfLocal->add(node);
+                  }
+               }
             }
          }
       if (_localObjects != NULL && local && local->isLocalObject())

--- a/compiler/optimizer/LiveVariableInformation.cpp
+++ b/compiler/optimizer/LiveVariableInformation.cpp
@@ -498,9 +498,6 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
             }
          else
             {
-            if (traceLiveVarInfo())
-               traceMsg(comp(), "            first reference, ");
-
             bool otherReferencesStillLive = false;
 
             // if this is a load, and there are no other live commoned loads of the local,
@@ -541,11 +538,18 @@ void TR_LiveVariableInformation::visitTreeForLocals(TR::Node *node, TR_BitVector
                {
                if (otherReferencesStillLive)
                   {
-                  traceMsg(comp(), "but other commoned references to this sym are still live\n");
+                  traceMsg(comp(), "            First reference to this node, but other commoned references to this local sym are still live\n");
                   }
                else
                   {
-                  traceMsg(comp(), "and this was the first of all commoned references to this sym\n");
+                  if (local != NULL)
+                     {
+                     traceMsg(comp(), "            First reference to this node, and either this is the first of all commoned references to this sym or this it is not a commoned reference\n");
+                     }
+                  else
+                     {
+                     traceMsg(comp(), "            First reference to this node\n");
+                     }
                   }
                }
             }


### PR DESCRIPTION
Store sinking tracks which local variables are used in the value assigned to a candidate store, tracks whether a load of a local variable has been commoned, and whether the load might be killed by a store to that local.  All this tracking is done on the basis of the index of the local variable.

However, it's possible for a local to be loaded before a store to that local, and the value that existed before that store to be used by the candidate for store sinking.  In general, there could be several loads and stores to such a local interleaved, with each of the distinct values loaded being used by commoned references in the store that's a candidate for store sinking.

This problem was fixed by having `LiveVariableInformation` keep track of the distinct nodes that load local variables in backwards tree walks, and the number of distinct loads for each local variable.

Also removed a redundant copy into `*savedLiveCommonedLoads` of the result of a call to `TR_LiveVariableInformation::liveCommonedLoads()`, and removed an unused `TR_BitVector` `satisfiedLiveCommonedLoads`.

Fixes:  eclipse-openj9/openj9#17033

Port of [OMR pull request #7844](https://github.com/eclipse-omr/omr/pull/7844/) to v0.54.0-release branch.