### PR TITLE
(0.55) Remove unknown features from get_processor_feature_string output

### DIFF
--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -165,7 +165,8 @@ omrsysinfo_get_processor_feature_name(struct OMRPortLibrary *portLibrary, uint32
 
 /**
  * Generate the corresponding string literals for the provided OMRProcessorDesc. The buffer will be zero 
- * initialized and overwritten with the processor feature output string.
+ * initialized and overwritten with the processor feature output string. The string will not contain "null",
+ * which corresponds to unknown feature names.
  *
  * @param[in] portLibrary The port library.
  * @param[in] desc The struct that contains the list of processor features to be converted to string.

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -921,7 +921,9 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 				uint32_t feature = (uint32_t)(i * numberOfBits + j);
 				const char * featureName = omrsysinfo_get_processor_feature_name(portLibrary, feature);
 				size_t featureLength = strlen(featureName);
-
+				if ((4 == featureLength) && (0 == strncmp("null", featureName, 4))) {
+					continue;
+				}
 				if (start == FALSE) {
 					strncat(buffer, " ", length - bufferLength - 1);
 					bufferLength += 1;

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -190,7 +190,9 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 				uint32_t feature = (uint32_t)(i * numberOfBits + j);
 				const char * featureName = omrsysinfo_get_processor_feature_name(portLibrary, feature);
 				size_t featureLength = strlen(featureName);
-
+				if ((4 == featureLength) && (0 == strncmp("null", featureName, 4))) {
+					continue;
+				}
 				if (start == FALSE) {
 					strncat(buffer, " ", length - bufferLength - 1);
 					bufferLength += 1;


### PR DESCRIPTION
omrsysinfo_get_processor_feature_string() may return a string that includes features called "null". omrsysinfo_get_processor_feature_name() by design returns "null" for unknown features. Remove "null" from the omrsysinfo_get_processor_feature_string() output.

cherry pick https://github.com/eclipse-omr/omr/pull/7857