### PR TITLE
Accommodate default and long-term future Power processors gracefully

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1110,7 +1110,11 @@ _error:
 static OMRProcessorArchitecture
 omrsysinfo_map_ppc_processor(const char *processorName)
 {
-	OMRProcessorArchitecture rc = OMR_PROCESSOR_PPC_UNKNOWN;
+#ifdef OMR_ENV_LITTLE_ENDIAN
+	OMRProcessorArchitecture rc = OMR_PROCESSOR_PPC_P8;
+#else  /* OMR_ENV_LITTLE_ENDIAN */
+	OMRProcessorArchitecture rc = OMR_PROCESSOR_PPC_P7;
+#endif /* OMR_ENV_LITTLE_ENDIAN */
 
 	if (0 == strncasecmp(processorName, "ppc403", 6)) {
 		rc = OMR_PROCESSOR_PPC_PWR403;
@@ -1150,6 +1154,11 @@ omrsysinfo_map_ppc_processor(const char *processorName)
 		rc = OMR_PROCESSOR_PPC_P10;
 	} else if (0 == strncasecmp(processorName, "power11", 7)) {
 		rc = OMR_PROCESSOR_PPC_P11;
+	} else if (0 == strncasecmp(processorName, "power1", 6)) {
+		/* Defer the long-term anticipated cases to the latest known state. */
+		if ((processorName[6] >= '2') && (processorName[6] <= '9')) {
+			rc = OMR_PROCESSOR_PPC_P11;
+		}
 	}
 
 	return rc;
@@ -1206,7 +1215,7 @@ omrsysinfo_get_aix_ppc_description(struct OMRPortLibrary *portLibrary, OMRProces
 	} else if (__power_latestKnownAndUp()) {
 		desc->processor = OMR_PROCESSOR_PPC_P11;
 	} else {
-		desc->processor = OMR_PROCESSOR_PPC_UNKNOWN;
+		desc->processor = OMR_PROCESSOR_PPC_P7;
 	}
 #if !defined(J9OS_I5_V6R1)
 	/* AIX physical processor */


### PR DESCRIPTION
Push it to Java25. From now on,
oldest processor supported on AIX and LinuxBE is POWER7; oldest processor supported on LinuxLE is POWER8;
Any future Power processors presented is recognized as POWER11 at this point of time.