### PR TITLE
(0.56) Enable wider short arraycopies on x86, emit vzeroupper when necessary

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1554,11 +1554,11 @@ public:
         _edoRecompSizeThreshold = 0;
         _edoRecompSizeThresholdInStartupMode = 0;
         _catchBlockCounterThreshold = 0;
-        _arraycopyRepMovsByteArrayThreshold = 32;
-        _arraycopyRepMovsCharArrayThreshold = 32;
-        _arraycopyRepMovsIntArrayThreshold = 32;
-        _arraycopyRepMovsLongArrayThreshold = 32;
-        _arraycopyRepMovsReferenceArrayThreshold = 32;
+        _arraycopyRepMovsByteArrayThreshold = 64;
+        _arraycopyRepMovsCharArrayThreshold = 64;
+        _arraycopyRepMovsIntArrayThreshold = 128;
+        _arraycopyRepMovsLongArrayThreshold = 128;
+        _arraycopyRepMovsReferenceArrayThreshold = 128;
         _codeCacheKind = TR::CodeCacheKind::DEFAULT_CC;
 
         memset(_options, 0, sizeof(_options));


### PR DESCRIPTION
Backport of https://github.com/eclipse-omr/omr/pull/7843.