### PR TITLE
(0.55) AArch64: Disable ArrayTranslateTRTO/TRTO255

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -196,14 +196,14 @@ OMR::ARM64::CodeGenerator::initialize()
          cg->setSupportsArraySet();
          }
 
-      static bool disableTRTO = (feGetEnv("TR_disableTRTO") != NULL);
-      if (!disableTRTO)
+      static bool enableTRTO = (feGetEnv("TR_enableTRTO") != NULL);
+      if (enableTRTO)
          {
          cg->setSupportsArrayTranslateTRTO();
          }
 
-      static bool disableTRTO255 = (feGetEnv("TR_disableTRTO255") != NULL);
-      if (!disableTRTO255)
+      static bool enableTRTO255 = (feGetEnv("TR_enableTRTO255") != NULL);
+      if (enableTRTO255)
          {
          cg->setSupportsArrayTranslateTRTO255();
          }


### PR DESCRIPTION
This commit disables ArrayTranslateTRTO and ArrayTranslateTRTO255 on AArch64 by default.

Original PR: https://github.com/eclipse-omr/omr/pull/7940

Issue: https://github.com/eclipse-openj9/openj9/issues/21946