### PR TITLE
(0.56.0) Enable considerAllAutosAsTacticalGlobalRegisterCandidates on AArch64

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -84,6 +84,11 @@ void OMR::ARM64::CodeGenerator::initialize()
     cg->setSupportsGlRegDeps();
     cg->setSupportsGlRegDepOnFirstBlock();
 
+    static const char *disableAllAutosAsGRACandidates = feGetEnv("TR_DisableConsiderAllAutosAsTacticalGRACandidates");
+    if (!disableAllAutosAsGRACandidates) {
+        cg->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
+    }
+
     cg->addSupportedLiveRegisterKind(TR_GPR);
     cg->addSupportedLiveRegisterKind(TR_FPR);
     cg->addSupportedLiveRegisterKind(TR_VRF);


### PR DESCRIPTION
Port of https://github.com/eclipse-omr/omr/pull/7953