### PR TITLE
Inline short, primitive, forward arraycopies on AArch64

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1188,6 +1188,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
     { "enableIdiomRecognition", "O\tenable Idiom Recognition", TR::Options::enableOptimization, idiomRecognition, 0,
      "P" },
 #endif
+    { "enableInlineAArch64PrimitiveForwardArraycopies", "O\tAArch64 code generation inlining of primitive, forward arraycopies",
+     SET_OPTION_BIT(TR_EnableInlineAArch64PrimitiveForwardArraycopies), "F", NOT_IN_SUBSET },
     { "enableInlineProfilingStats", "O\tenable stats about profile based inlining",
      SET_OPTION_BIT(TR_VerboseInlineProfiling), "F" },
     { "enableInliningDuringVPAtWarm", "O\tenable inlining during VP for warm bodies",
@@ -5689,6 +5691,16 @@ void OMR::Options::setAggressiveThroughput()
     self()->setDisabled(OMR::loopStrider, true);
     self()->setDisabled(OMR::escapeAnalysis, true);
     self()->setOption(TR_DisableLoopTransfer);
+
+#if defined(TR_TARGET_ARM64)
+    /**
+     * Allow AArch64 code generator to more aggressively inline primitive,
+     * forward arraycopies. This will help workloads that tend to have a
+     * number of smaller primitive arraycopies.
+     */
+    self()->setOption(TR_EnableInlineAArch64PrimitiveForwardArraycopies);
+#endif
+
 #endif
     self()->setOption(TR_DisablePersistIProfile); // Want to rely on freshly collected IProfiler data
     self()->setOption(TR_UseHigherMethodCounts); // Increase counts to gather more IProfiler data

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -459,7 +459,7 @@ enum TR_CompilationOptions {
     TR_DisableHighWordRA                                     = 0x00800000 + 11, // zGryphon
     TR_DisableZImplicitNullChecks                            = 0x01000000 + 11,
     TR_DisablePrexistenceDuringGracePeriod                   = 0x02000000 + 11,
-    // Available                                             = 0x04000000 + 11,
+    TR_EnableInlineAArch64PrimitiveForwardArraycopies        = 0x04000000 + 11,
     TR_DisableInlineWriteBarriersRT                          = 0x08000000 + 11, // RTJ
     // Available                                             = 0x10000000 + 11,
     TR_DisableNewInliningInfrastructure                      = 0x20000000 + 11,


### PR DESCRIPTION
Forward arraycopies are expected to be the common case, and investigation on other platforms suggests that arraycopies <= 63 bytes are important in a number of workloads and will benefit from being specialized inline.

The feature is enabled under `AGGRESSIVE_THROUGHPUT` in OMROptions.cpp.

This optimization can be disabled by setting the environment variable `TR_DisableInlinePrimitiveForwardArraycopy`