### PR TITLE
(0.56) Allow pre-eval escaping conversion nodes of evaluated array-access

### DIFF
--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -616,11 +616,12 @@ void OMR::TreeEvaluator::evaluateNodesWithFutureUses(TR::Node *node, TR::CodeGen
 
         if (actualLoadOrStoreChild->getOpCode().isStore() || actualLoadOrStoreChild->getOpCode().isLoadConst()
             || actualLoadOrStoreChild->getOpCode().isArrayRef()
-            || (actualLoadOrStoreChild->getOpCode().isLoad() && actualLoadOrStoreChild->getSymbolReference()
+            || (actualLoadOrStoreChild->getOpCode().isLoad() && !actualLoadOrStoreChild->getRegister()
+                && actualLoadOrStoreChild->getSymbolReference()
                 && (actualLoadOrStoreChild->getSymbolReference()->getSymbol()->isArrayShadowSymbol()
                     || actualLoadOrStoreChild->getSymbolReference()->getSymbol()->isArrayletShadowSymbol()))) {
             // These types of nodes are likey specific to one path or another and may cause
-            // a failure if evaluated on a common path.
+            // a failure if evaluated on a common path. Except array accesses if already evaluated.
             //
             if (comp->getOption(TR_TraceCG)) {
                 traceMsg(comp,


### PR DESCRIPTION
Port of https://github.com/eclipse-omr/omr/pull/7967

preEvaluateEscapingNodesForSpineCheck gets called to pre-evaluate a future used commoned node before branching out of mainline code. It restricts pre-evaluating conversions with array-access children for correctness of access. But if array-access is already evaluated this restriction is non-beneficial and might prevent a needed pre-evaluation into the mainline code for a future used commoned node.