### PR TITLE
Fix duplicated bulletin for `__yield`

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -93,7 +93,9 @@
 		inline void __yield() { __asm__ volatile (" nop 0"); }
 #pragma convlit(resume)
 #elif defined(AARCH64) /* defined(J9ZOS390) */
+#if !__has_builtin(__yield)
 		inline void __yield() { __asm__ volatile ("yield"); }
+#endif /* !__has_builtin(__yield) */
 #else /* defined(AARCH64) */
 		inline void __yield() { __asm volatile ("# AtomicOperations::__yield"); }
 #endif /* defined(AIXPPC) */


### PR DESCRIPTION
It seems that apple clang 21+ is defined `__yield` bulletin and so it will be duplicated and gets an error. So, let's check it is already defined or not.

I think the related PR is
- https://github.com/llvm/llvm-project/pull/128222