### PR TITLE
(0.60) Disable using MVC for store nodes

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -461,6 +461,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      SET_OPTION_BIT(TR_DisableDependencyTracking), "F" },
     { "disableDirectMemoryOps", "O\tdisable generation of direct memory instructions",
      SET_OPTION_BIT(TR_DisableDirectMemoryOps), "F" },
+    { "disableDirectMemoryStore", "O\tdisable generation of direct memory store instructions",
+     SET_OPTION_BIT(TR_DisableDirectMemoryStore), "F" },
     { "disableDirectStaticAccessOnZ", "O\tsupport relative load instructions for c and c++",
      SET_OPTION_BIT(TR_DisableDirectStaticAccessOnZ), "F" },
     { "disableDirectToJNI", "O\tdisable all JNI linkage dispatch sequences including thunks",
@@ -1174,6 +1176,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      RESET_OPTION_BIT(TR_DisableDependencyTracking), "F" },
     { "enableDeterministicOrientedCompilation", "O\tenable deterministic oriented compilation",
      SET_OPTION_BIT(TR_EnableDeterministicOrientedCompilation), "F" },
+    { "enableDirectMemoryStore", "O\tenable generating direct memory store instructions",
+     RESET_OPTION_BIT(TR_DisableDirectMemoryStore), "F" },
     { "enableDLTBytecodeIndex=", "O<nnn>\tforce attempted DLT compilation to use specified bytecode index",
      TR::Options::set32BitNumeric, offsetof(OMR::Options, _enableDLTBytecodeIndex), 0, "F%d" },
     { "enableDowngradeOnHugeQSZ",
@@ -3651,6 +3655,13 @@ void OMR::Options::jitPreProcess()
     self()->setOption(TR_EnableCodeCacheConsolidation);
 #endif
 
+#if defined(TR_HOST_S390)
+    // On IBM Z, usage of direct memory store without checking memory reference
+    // for destructive overlap can cause functional issue. Disabling the use of
+    // MVC code store operation on Z. With sufficient checks at compile time to
+    // guarantee no overlap, it can be enabled.
+    self()->setOption(TR_DisableDirectMemoryStore);
+#endif
     // --------------------------------------------------------------------------
     // J9-only
     //

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -446,7 +446,7 @@ enum TR_CompilationOptions {
     TR_DisableVectorAPIBoxing                                = 0x00000040 + 11,
     TR_EnableSelectiveEnterExitHooks                         = 0x00000080 + 11,
     TR_EnableUseDefBasedVectorAPIExpansion                   = 0x00000100 + 11,
-    // Available                                             = 0x00000200 + 11,
+    TR_DisableDirectMemoryStore                              = 0x00000200 + 11,
     // Available                                             = 0x00000400 + 11,
     TR_DisableConstProvenance                                = 0x00000800 + 11,
     TR_DisableITableIterationsAfterLastITableCacheCheck      = 0x00001000 + 11,

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7325,7 +7325,7 @@ bool storeHelperImmediateInstruction(TR::Node *valueChild, TR::CodeGenerator *cg
  */
 bool directMemoryStoreHelper(TR::CodeGenerator *cg, TR::Node *storeNode)
 {
-    if (!cg->getConditionalMovesEvaluationMode()) {
+    if (!cg->getConditionalMovesEvaluationMode() && !cg->comp()->getOption(TR_DisableDirectMemoryStore)) {
         if (storeNode->getType().isIntegral()
             && !(storeNode->getOpCode().isIndirect() && storeNode->hasUnresolvedSymbolReference())) {
             TR::Node *valueNode = storeNode->getOpCode().isIndirect() ? storeNode->getChild(1) : storeNode->getChild(0);
@@ -7587,18 +7587,6 @@ TR::MemoryReference *lstoreHelper64(TR::Node *node, TR::CodeGenerator *cg, bool 
                     (longMR = TR::MemoryReference::create(cg, node)))) {
                 valueReg = cg->evaluate(valueChild);
             }
-        }
-        // lload is the child, then don't evaluate the child, generate MVC to move directly among memory
-        else if (!node->getOpCode().isIndirect() && valueChild->getOpCodeValue() == TR::lload
-            && valueChild->getReferenceCount() == 1 && valueChild->getRegister() == NULL
-            && TR::MemoryReference::create(cg, node)->getIndexRegister() == NULL
-            && !cg->getConditionalMovesEvaluationMode()) {
-            TR::MemoryReference *tempMRSource = TR::MemoryReference::create(cg, valueChild);
-            TR::MemoryReference *tempMRDest = TR::MemoryReference::create(cg, node);
-            generateSS1Instruction(cg, TR::InstOpCode::MVC, node, int16_t(node->getSize() - 1), tempMRDest,
-                tempMRSource);
-            cg->decReferenceCount(valueChild);
-            return tempMRDest;
         } else {
             valueReg = cg->evaluate(valueChild);
             longMR = TR::MemoryReference::create(cg, node);


### PR DESCRIPTION
On IBM Z, we would try to find opportunity to generate memory copy when we are storing a value to a memory reference by loading it from another memory reference.
In case we know for sure that there is no overlap, generating such instruction is safe to do so, but in case if memory references overlap, it would be impossible in certain cases to know if it is destructive overlap or not. This leads to possibility where we can end up with generating memory copy with destructive overlap which would corrupt the memory.

I am adding option to disable generation of MVC instructions when the value operand is in memory. By default this option is set to disable the generation.