### PR TITLE
(v0.60) AArch64: Add setLastInstruction() to BBEndEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -7443,7 +7443,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
     }
 
     // put the dependencies (if any) on the fence
-    generateAdminInstruction(cg, TR::InstOpCode::fence, node, deps, fenceNode);
+    TR::Instruction *instr = generateAdminInstruction(cg, TR::InstOpCode::fence, node, deps, fenceNode);
+    node->getBlock()->setLastInstruction(instr);
 
     return NULL;
 }


### PR DESCRIPTION
This commit adds a call to block->setLastInstruction() to BBEndEvaluator() for AArch64.

Original PR: https://github.com/eclipse-omr/omr/pull/8280
Related issue: https://github.com/eclipse-openj9/openj9/issues/24119