### PR TITLE
(0.62) Call addSimplifierCommon at the end of laddSimplifier

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -6272,7 +6272,7 @@ TR::Node *laddSimplifier(TR::Node *node, TR::Block *block, TR::Simplifier *s)
         }
     }
     addSimplifierJavaPacked(node, block, s);
-    return node;
+    return addSimplifierCommon(node, block, s);
 }
 
 TR::Node *faddSimplifier(TR::Node *node, TR::Block *block, TR::Simplifier *s)


### PR DESCRIPTION
- similar to iaddSimplfier, laddSimplfier can benefit from addSimplifierCommon

Double deliver of https://github.com/eclipse-omr/omr/pull/8364