### PR TITLE
(0.63) Don't use interfaces as type of monent/monexit

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2907,6 +2907,11 @@ TR::Node *constrainMonent(OMR::ValuePropagation *vp, TR::Node *node)
         if (clazz && (TR::Compiler->cls.classDepthOf(clazz) == 0) && !constraint->isFixedClass())
             clazz = NULL;
 
+        // Don't use interface classes for monitors as it will incorrectly trigger the fixed offset inline sequence
+        // in codegen, even if the concrete class doesn't have a lockword at the corresponding offset.
+        if (clazz && TR::Compiler->cls.isInterfaceClass(vp->comp(), clazz))
+            clazz = NULL;
+
         if (node->hasMonitorClassInNode() && clazz && (node->getMonitorClassInNode() != clazz)) {
             TR_YesNoMaybe answer = vp->fe()->isInstanceOf(clazz, node->getMonitorClassInNode(), true, true);
             if (answer != TR_yes)
@@ -2946,6 +2951,11 @@ TR::Node *constrainMonexit(OMR::ValuePropagation *vp, TR::Node *node)
             clazz = vp->fe()->getClassClassPointer(clazz);
 
         if (clazz && (TR::Compiler->cls.classDepthOf(clazz) == 0) && !constraint->isFixedClass())
+            clazz = NULL;
+
+        // Don't use interface classes for monitors as it will incorrectly trigger the fixed offset inline sequence
+        // in codegen, even if the concrete class doesn't have a lockword at the corresponding offset.
+        if (clazz && TR::Compiler->cls.isInterfaceClass(vp->comp(), clazz))
             clazz = NULL;
 
         if (node->hasMonitorClassInNode() && clazz && (node->getMonitorClassInNode() != clazz)) {


### PR DESCRIPTION
Backport of https://github.com/eclipse-omr/omr/pull/8411

Codegen bases decisions on whether/how to inline monitor entry and exit sequences on the lockOffset field of the J9Class of the monitor, if known. Interfaces have a (surprising) lockOffset of 4, so if VP sets an Interface as the type of a monitor codegen (at least the AMD64 version) will generate an unconditional inlined compare and swap sequence at offset 4. If the concrete type is an array, offset 4 holds the size of the array, not a lockword, and this can result in crashes when the size is replaced with the J9VMThread.

This change avoids the problem by preventing the constrainMonent and constrainMonExit functions from setting the class of the monitor to an interface.